### PR TITLE
Apple silicon runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ env:
 jobs:
   build:
     name: Test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ rust-toolchain.toml
 
 # Avoid pushing statistics report from CLI output
 *.log
+
+# Mac OS DS_Store file
+.DS_Store


### PR DESCRIPTION
Added build on `macos-latest` to ensure successful compilation on Apple Silicon.

Closes #42 