### PR TITLE
Updated `pathfinder_simd` to 0.5.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,36 @@ jobs:
     - name: Run tests
       run: cargo test --locked
 
+  build_nightly:
+    name: Test Nightly
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "build-cache-nightly"
+        cache-all-crates: "true"
+        cache-directories: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+    - name: Install rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        override: true
+    - name: Build
+      run: cargo build --locked
+    - name: Run tests
+      run: cargo test --locked
+
   clippy:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ env:
 jobs:
   build:
     name: Test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ rust-toolchain.toml
 
 # Avoid pushing statistics report from CLI output
 *.log
+
+# Mac OS DS_Store file
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf45976c56919841273f2a0fc684c28437e2f304e264557d9c72be5d5a718be"
+checksum = "5cf07ef4804cfa9aea3b04a7bbdd5a40031dbb6b4f2cbaf2b011666c80c5b4f2"
 dependencies = [
  "rustc_version",
 ]


### PR DESCRIPTION
Updated `pathfinder_simd` dependency to `v0.5.4` to make `starknet-replay` compatible with nightly (currently 1.82) version of Rust on ARM.

Also added Nightly build on CI.

Closes #43 .