### PR TITLE
Rpc client optimisations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,36 +31,6 @@ jobs:
     - name: Run tests
       run: cargo test --locked
 
-  build_nightly:
-    name: Test Nightly
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: "build-cache-nightly"
-        cache-all-crates: "true"
-        cache-directories: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-    - name: Install rust nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        override: true
-    - name: Build
-      run: cargo build --locked
-    - name: Run tests
-      run: cargo test --locked
-
   clippy:
     name: Lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ histogram in the file named `"histogram.svg"`.
 
 ## Limitations
 
-- Libfunc frequency results haven't been checked yet.
-- Log of transaction traces to JSON requires a lot of memory allocation. It
-  still needs to be optimised.
+Libfunc frequency results haven't been checked yet.
+
+## Requirements
+
+This crate is compatible with Rust 1.78. Both x86 and ARM are supported.
 
 ## Useful links
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Starknet Replay
 
 `starknet-replay` is a CLI application to replay Starknet transactions. The
-state of the blockchain is queried using the Starknet RPC protocol.
-It also reports the frequency with which each `libfunc` has been called when
-replaying the transactions.
+state of the blockchain is queried using the Starknet RPC protocol. It also
+reports the frequency with which each `libfunc` has been called when replaying
+the transactions.
 
-It's possible to export the histogram of the most frequently used libfuncs
-by number of calls. The data plotted in the histogram is filtered to only
-include the libfuncs that amount to 80% of the total calls in the replay. This
-helps readability and visual analysis.
+It's possible to export the histogram of the most frequently used libfuncs by
+number of calls. The data plotted in the histogram is filtered to only include
+the libfuncs that amount to 80% of the total calls in the replay. This helps
+readability and visual analysis.
 
 Only `INVOKE` transactions of Sierra contracts are used for this report because
 only Sierra contracts use libfuncs and only `INVOKE` transactions execute Sierra
@@ -49,6 +49,9 @@ Libfunc frequency results haven't been checked yet.
 ## Requirements
 
 This crate is compatible with Rust 1.78. Both x86 and ARM are supported.
+
+`blockifier` dependency is not compatible with Rust 1.81+. `pathfinder_simp`
+dependency is not compatible with Rust 1.83+ on ARM.
 
 ## Useful links
 

--- a/starknet-replay/src/runner/mod.rs
+++ b/starknet-replay/src/runner/mod.rs
@@ -99,7 +99,7 @@ where
     for block_number in start_block.get()..=last_block.get() {
         let block_number = BlockNumber::new(block_number);
 
-        let (transactions, receipts) =
+        let (block_header, transactions, receipts) =
             storage.get_transactions_and_receipts_for_block(block_number)?;
 
         let transactions_to_process = transactions.len();
@@ -107,8 +107,7 @@ where
             "{transactions_to_process} transactions to process in block {block_number:?}"
         );
 
-        let header = storage.get_block_header(block_number)?;
-        let replay_block = ReplayBlock::new(header, transactions, receipts)?;
+        let replay_block = ReplayBlock::new(block_header, transactions, receipts)?;
         replay_blocks.push(replay_block);
     }
 

--- a/starknet-replay/src/storage/mod.rs
+++ b/starknet-replay/src/storage/mod.rs
@@ -65,7 +65,7 @@ pub trait Storage {
     fn get_transactions_and_receipts_for_block(
         &self,
         block_number: BlockNumber,
-    ) -> Result<(Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError>;
+    ) -> Result<(BlockHeader, Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError>;
 
     /// Replays the list of transactions in a block and returns the list of
     /// transactions traces.

--- a/starknet-replay/src/storage/mod.rs
+++ b/starknet-replay/src/storage/mod.rs
@@ -15,6 +15,10 @@ use crate::{ReplayBlock, RunnerError};
 
 pub mod rpc;
 
+/// The type [`BlockWithReceipts`] bundles together all the block data: block
+/// header, transaction data and receipt data.
+pub type BlockWithReceipts = (BlockHeader, Vec<Transaction>, Vec<TransactionReceipt>);
+
 pub trait Storage {
     /// Returns the most recent block number available in the storage.
     ///
@@ -65,7 +69,7 @@ pub trait Storage {
     fn get_transactions_and_receipts_for_block(
         &self,
         block_number: BlockNumber,
-    ) -> Result<(BlockHeader, Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError>;
+    ) -> Result<BlockWithReceipts, DatabaseError>;
 
     /// Replays the list of transactions in a block and returns the list of
     /// transactions traces.

--- a/starknet-replay/src/storage/rpc/mod.rs
+++ b/starknet-replay/src/storage/rpc/mod.rs
@@ -83,8 +83,6 @@ static VERSIONED_CONSTANTS_13_1: Lazy<VersionedConstants> = Lazy::new(|| {
 #[allow(dead_code)]
 pub struct RpcStorage {
     /// The endpoint of the Starknet RPC Node.
-    ///
-    /// Unused but kept for reference.
     rpc_client: RpcClient,
 }
 impl RpcStorage {
@@ -342,7 +340,7 @@ impl ReplayStorage for RpcStorage {
     fn get_transactions_and_receipts_for_block(
         &self,
         block_number: BlockNumber,
-    ) -> Result<(Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError> {
+    ) -> Result<(BlockHeader, Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError> {
         let transactions = self
             .rpc_client
             .starknet_get_block_with_receipts(&block_number)?;

--- a/starknet-replay/src/storage/rpc/mod.rs
+++ b/starknet-replay/src/storage/rpc/mod.rs
@@ -24,7 +24,7 @@ use rpc_client::RpcClient;
 use starknet_api::block::{BlockHeader, StarknetVersion};
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::data_availability::L1DataAvailabilityMode;
-use starknet_api::transaction::{Transaction, TransactionExecutionStatus, TransactionReceipt};
+use starknet_api::transaction::{Transaction, TransactionExecutionStatus};
 use starknet_api::{contract_address, felt, patricia_key};
 use starknet_core::types::{
     ContractClass,
@@ -41,6 +41,7 @@ use tracing::{error, info, warn};
 use url::Url;
 
 use self::visited_pcs::VisitedPcsRaw;
+use super::BlockWithReceipts;
 use crate::block_number::BlockNumber;
 use crate::error::{DatabaseError, RunnerError};
 use crate::runner::replay_block::ReplayBlock;
@@ -342,7 +343,7 @@ impl ReplayStorage for RpcStorage {
     fn get_transactions_and_receipts_for_block(
         &self,
         block_number: BlockNumber,
-    ) -> Result<(BlockHeader, Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError> {
+    ) -> Result<BlockWithReceipts, DatabaseError> {
         let transactions = self
             .rpc_client
             .starknet_get_block_with_receipts(&block_number)?;

--- a/starknet-replay/src/storage/rpc/mod.rs
+++ b/starknet-replay/src/storage/rpc/mod.rs
@@ -1,7 +1,9 @@
-//! This module uses the Starknet RPC protocol to query the data required to
-//! replay transactions from the Starknet blockchain.
+//! This module contains the implementation of the [`crate::storage::Storage`]
+//! trait to replay transactions using the RPC client interface.
 
-#![allow(clippy::module_name_repetitions)] // Added because of `ClassInfo`
+#![allow(clippy::module_name_repetitions)] // Added because of `generate_class_info` in `class_info.rs`, `convert_receipt`
+                                           // in `receipt.rs`, `convert_transaction` in `transaction.rs`,
+                                           // `VisitedPcsRaw` in `visited_pcs. rs`, `RpcStorage` in `mod.rs`
 
 use std::collections::BTreeMap;
 use std::num::NonZeroU128;

--- a/starknet-replay/src/storage/rpc/mod.rs
+++ b/starknet-replay/src/storage/rpc/mod.rs
@@ -402,9 +402,11 @@ impl ReplayStorage for RpcStorage {
         let old_block_number_and_hash = if work.header.block_number.0 >= 10 {
             let block_number_whose_hash_becomes_available =
                 BlockNumber::new(work.header.block_number.0 - 10);
+            // TODO: in case of multiple blocks replay, the block hash is already queried
+            // when the vector of `ReplayBlock` is generated. This data could be reused in a
+            // shared variabled.
             let block_hash = self
-                .rpc_client
-                .starknet_get_block_with_tx_hashes(&block_number_whose_hash_becomes_available)?
+                .get_block_header(block_number_whose_hash_becomes_available)?
                 .block_hash;
 
             Some(BlockNumberHashPair::new(

--- a/starknet-replay/src/storage/rpc/rpc_client.rs
+++ b/starknet-replay/src/storage/rpc/rpc_client.rs
@@ -1,7 +1,5 @@
-//! This module uses the Starknet RPC protocol to query the data required to
-//! replay transactions from the Starknet blockchain.
-
-#![allow(clippy::module_name_repetitions)] // Added because of `ClassInfo`
+//! This module uses the Starknet RPC protocol to query the data from the
+//! Starknet RPC server.
 
 use starknet_api::block::{
     BlockHash,

--- a/starknet-replay/src/storage/rpc/rpc_client.rs
+++ b/starknet-replay/src/storage/rpc/rpc_client.rs
@@ -41,6 +41,7 @@ use crate::error::DatabaseError;
 use crate::runner::replay_class_hash::ReplayClassHash;
 use crate::storage::rpc::receipt::convert_receipt;
 use crate::storage::rpc::transaction::convert_transaction;
+use crate::storage::BlockWithReceipts;
 
 /// This structure partially implements a Starknet RPC client.
 ///
@@ -158,7 +159,7 @@ impl RpcClient {
                 let data_price_in_wei: u128 =
                     block.l1_data_gas_price.price_in_wei.to_string().parse()?;
 
-                let block_header: BlockHeader = BlockHeader {
+                let block_header = BlockHeader {
                     block_hash: BlockHash(Felt::from_bytes_be(&block.block_hash.to_bytes_be())),
                     parent_hash: BlockHash(Felt::from_bytes_be(&block.parent_hash.to_bytes_be())),
                     block_number: starknet_api::block::BlockNumber(block.block_number),
@@ -210,7 +211,7 @@ impl RpcClient {
     pub async fn starknet_get_block_with_receipts(
         &self,
         block_number: &BlockNumber,
-    ) -> Result<(BlockHeader, Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError> {
+    ) -> Result<BlockWithReceipts, DatabaseError> {
         let block_id: BlockId = block_number.into();
         let txs_with_receipts: MaybePendingBlockWithReceipts = self
             .get_new_client()
@@ -228,7 +229,7 @@ impl RpcClient {
                 let data_price_in_wei: u128 =
                     block.l1_data_gas_price.price_in_wei.to_string().parse()?;
 
-                let block_header: BlockHeader = BlockHeader {
+                let block_header = BlockHeader {
                     block_hash: BlockHash(Felt::from_bytes_be(&block.block_hash.to_bytes_be())),
                     parent_hash: BlockHash(Felt::from_bytes_be(&block.parent_hash.to_bytes_be())),
                     block_number: starknet_api::block::BlockNumber(block.block_number),

--- a/starknet-replay/src/storage/rpc/rpc_client.rs
+++ b/starknet-replay/src/storage/rpc/rpc_client.rs
@@ -1,0 +1,373 @@
+//! This module uses the Starknet RPC protocol to query the data required to
+//! replay transactions from the Starknet blockchain.
+
+#![allow(clippy::module_name_repetitions)] // Added because of `ClassInfo`
+
+use starknet_api::block::{
+    BlockHash,
+    BlockHeader,
+    BlockTimestamp,
+    GasPrice,
+    GasPricePerToken,
+    StarknetVersion,
+};
+use starknet_api::core::{
+    ChainId,
+    ClassHash,
+    ContractAddress,
+    GlobalRoot,
+    Nonce,
+    SequencerContractAddress,
+};
+use starknet_api::data_availability::L1DataAvailabilityMode;
+use starknet_api::hash::StarkHash;
+use starknet_api::state::StorageKey;
+use starknet_api::transaction::{Transaction, TransactionReceipt};
+use starknet_core::types::{
+    BlockId,
+    ContractClass,
+    Felt,
+    MaybePendingBlockWithReceipts,
+    MaybePendingBlockWithTxHashes,
+    StarknetError,
+};
+use starknet_providers::jsonrpc::HttpTransport;
+use starknet_providers::{JsonRpcClient, Provider, ProviderError};
+use tracing::trace;
+use url::Url;
+
+use crate::block_number::BlockNumber;
+use crate::contract_address::to_field_element;
+use crate::error::DatabaseError;
+use crate::runner::replay_class_hash::ReplayClassHash;
+use crate::storage::rpc::receipt::convert_receipt;
+use crate::storage::rpc::transaction::convert_transaction;
+
+/// This structure partially implements a Starknet RPC client.
+///
+/// The RPC calls included are those needed to replay transactions.
+/// Clone is not derived because it's not supported by Client.
+pub struct RpcClient {
+    /// The endpoint of the Starknet RPC Node.
+    endpoint: Url,
+}
+impl RpcClient {
+    /// Constructs a new `RpcStorage`.
+    ///
+    /// # Arguments
+    ///
+    /// - `endpoint`: The Url of the Starknet RPC node.
+    #[must_use]
+    pub fn new(endpoint: Url) -> Self {
+        RpcClient { endpoint }
+    }
+
+    /// This function generates a new client to perform an RPC request to the
+    /// endpoint.
+    ///
+    /// The client can't be shared across threads.
+    fn get_new_client(&self) -> JsonRpcClient<HttpTransport> {
+        JsonRpcClient::new(HttpTransport::new(self.endpoint.clone()))
+    }
+
+    /// This function queries the number of the most recent Starknet block.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_block_number(&self) -> Result<BlockNumber, DatabaseError> {
+        let block_number: u64 = self.get_new_client().block_number().await?;
+        Ok(BlockNumber::new(block_number))
+    }
+
+    /// This function queries the contract class at a specific block.
+    ///
+    /// # Arguments
+    ///
+    /// - `class_hash_at_block`: class hash of the contract to be returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails or the class hash doesn't exist.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_get_class(
+        &self,
+        class_hash_at_block: &ReplayClassHash,
+    ) -> Result<ContractClass, DatabaseError> {
+        let block_id: BlockId = class_hash_at_block.block_number.into();
+        let class_hash: Felt = class_hash_at_block.class_hash.0;
+        let contract_class: ContractClass = self
+            .get_new_client()
+            .get_class(block_id, class_hash)
+            .await?;
+        Ok(contract_class)
+    }
+
+    /// This function queries the block header.
+    ///
+    /// # Arguments
+    ///
+    /// - `block_number`: the block number to be queried.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails or the block number doesn't exist.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_get_block_with_tx_hashes(
+        &self,
+        block_number: &BlockNumber,
+    ) -> Result<BlockHeader, DatabaseError> {
+        let block_id: BlockId = block_number.into();
+        let block_header: MaybePendingBlockWithTxHashes = self
+            .get_new_client()
+            .get_block_with_tx_hashes(block_id)
+            .await?;
+        match block_header {
+            MaybePendingBlockWithTxHashes::Block(block_header) => {
+                let sequencer: StarkHash =
+                    Felt::from_bytes_be(&block_header.sequencer_address.to_bytes_be());
+                let price_in_fri: u128 =
+                    block_header.l1_gas_price.price_in_fri.to_string().parse()?;
+                let price_in_wei: u128 =
+                    block_header.l1_gas_price.price_in_wei.to_string().parse()?;
+
+                let data_price_in_fri: u128 = block_header
+                    .l1_data_gas_price
+                    .price_in_fri
+                    .to_string()
+                    .parse()?;
+                let data_price_in_wei: u128 = block_header
+                    .l1_data_gas_price
+                    .price_in_wei
+                    .to_string()
+                    .parse()?;
+
+                let block_header: BlockHeader = BlockHeader {
+                    block_hash: BlockHash(Felt::from_bytes_be(
+                        &block_header.block_hash.to_bytes_be(),
+                    )),
+                    parent_hash: BlockHash(Felt::from_bytes_be(
+                        &block_header.parent_hash.to_bytes_be(),
+                    )),
+                    block_number: starknet_api::block::BlockNumber(block_header.block_number),
+                    l1_gas_price: GasPricePerToken {
+                        price_in_fri: GasPrice(price_in_fri),
+                        price_in_wei: GasPrice(price_in_wei),
+                    },
+                    l1_data_gas_price: GasPricePerToken {
+                        price_in_fri: GasPrice(data_price_in_fri),
+                        price_in_wei: GasPrice(data_price_in_wei),
+                    },
+                    state_root: GlobalRoot(Felt::from_bytes_be(
+                        &block_header.new_root.to_bytes_be(),
+                    )),
+                    sequencer: SequencerContractAddress(sequencer.try_into()?),
+                    timestamp: BlockTimestamp(block_header.timestamp),
+                    l1_da_mode: match block_header.l1_da_mode {
+                        starknet_core::types::L1DataAvailabilityMode::Blob => {
+                            L1DataAvailabilityMode::Blob
+                        }
+                        starknet_core::types::L1DataAvailabilityMode::Calldata => {
+                            L1DataAvailabilityMode::Calldata
+                        }
+                    },
+                    state_diff_commitment: None,
+                    transaction_commitment: None,
+                    event_commitment: None,
+                    n_transactions: block_header.transactions.len(),
+                    n_events: 0,
+                    starknet_version: StarknetVersion(block_header.starknet_version),
+                    state_diff_length: None,
+                    receipt_commitment: None,
+                };
+                Ok(block_header)
+            }
+            MaybePendingBlockWithTxHashes::PendingBlock(_) => unreachable!(),
+        }
+    }
+
+    /// This function queries the transactions and receipts in a block.
+    ///
+    /// # Arguments
+    ///
+    /// - `block_number`: the block number to be queried.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails or the block number doesn't exist.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_get_block_with_receipts(
+        &self,
+        block_number: &BlockNumber,
+    ) -> Result<(Vec<Transaction>, Vec<TransactionReceipt>), DatabaseError> {
+        let block_id: BlockId = block_number.into();
+        let txs_with_receipts: MaybePendingBlockWithReceipts = self
+            .get_new_client()
+            .get_block_with_receipts(block_id)
+            .await?;
+        match txs_with_receipts {
+            MaybePendingBlockWithReceipts::Block(block) => {
+                let mut transactions: Vec<Transaction> =
+                    Vec::with_capacity(block.transactions.len());
+                let mut receipts: Vec<TransactionReceipt> =
+                    Vec::with_capacity(block.transactions.len());
+
+                for tx in block.transactions {
+                    let transaction = convert_transaction(tx.transaction)?;
+                    let receipt =
+                        convert_receipt(&block.block_hash, &block.block_number, tx.receipt)?;
+                    transactions.push(transaction);
+                    receipts.push(receipt);
+                }
+                Ok((transactions, receipts))
+            }
+            MaybePendingBlockWithReceipts::PendingBlock(_) => unreachable!(),
+        }
+    }
+
+    /// This function queries the nonce of a contract.
+    ///
+    /// # Arguments
+    ///
+    /// - `block_number`: the block number at which to query the nonce.
+    /// - `contract_address`: the address of the contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails or the block number doesn't exist.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_get_nonce(
+        &self,
+        block_number: &BlockNumber,
+        contract_address: &ContractAddress,
+    ) -> Result<Nonce, DatabaseError> {
+        trace!(
+            "starknet_get_nonce {:?} {:?}",
+            block_number,
+            contract_address
+        );
+        let block_id: BlockId = block_number.into();
+        let contract_address: Felt = to_field_element(contract_address);
+        let req = self
+            .get_new_client()
+            .get_nonce(block_id, contract_address)
+            .await;
+        Ok(match req {
+            Ok(nonce) => Ok(Nonce(nonce)),
+            Err(err) => match err {
+                ProviderError::StarknetError(StarknetError::ContractNotFound) => {
+                    Ok(Nonce(Felt::ZERO))
+                }
+                _ => Err(err),
+            },
+        }?)
+    }
+
+    /// This function queries the class hash of a contract.
+    ///
+    /// Returns 0 if the class hash doesn't exist.
+    ///
+    /// # Arguments
+    ///
+    /// - `block_number`: the block number at which to query the class hash.
+    /// - `contract_address`: the address of the contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_get_class_hash_at(
+        &self,
+        block_number: &BlockNumber,
+        contract_address: &ContractAddress,
+    ) -> Result<ClassHash, DatabaseError> {
+        trace!(
+            "starknet_get_class_hash_at {:?} {:?}",
+            block_number,
+            contract_address
+        );
+        let block_id: BlockId = block_number.into();
+        let contract_address: Felt = to_field_element(contract_address);
+        let req = self
+            .get_new_client()
+            .get_class_hash_at(block_id, contract_address)
+            .await;
+        Ok(match req {
+            Ok(class_hash) => Ok(ClassHash(class_hash)),
+            Err(err) => match err {
+                ProviderError::StarknetError(StarknetError::ContractNotFound) => {
+                    Ok(ClassHash(Felt::ZERO))
+                }
+                _ => Err(err),
+            },
+        }?)
+    }
+
+    /// This function queries the value of a storage key.
+    ///
+    /// Returns 0 if the storage key doesn't exist.
+    ///
+    /// # Arguments
+    ///
+    /// - `block_number`: the block number at which to query the storage key.
+    /// - `contract_address`: the address of the contract.
+    /// - `key`: the storage key to query.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_get_storage_at(
+        &self,
+        block_number: &BlockNumber,
+        contract_address: &ContractAddress,
+        key: &StorageKey,
+    ) -> Result<Felt, DatabaseError> {
+        trace!(
+            "starknet_get_storage_at {:?} {:?} {:?}",
+            block_number,
+            contract_address,
+            key
+        );
+        let block_id: BlockId = block_number.into();
+        let contract_address: Felt = to_field_element(contract_address);
+        let key: Felt = to_field_element(key);
+        let req = self
+            .get_new_client()
+            .get_storage_at(contract_address, key, block_id)
+            .await;
+        Ok(match req {
+            Ok(storage_value) => Ok(storage_value),
+            Err(err) => match err {
+                ProviderError::StarknetError(StarknetError::ContractNotFound) => Ok(Felt::ZERO),
+                _ => Err(err),
+            },
+        }?)
+    }
+
+    /// This function queries the chain id of the RPC endpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the request fails or decoding hex values of the chain
+    /// id fails.
+    #[allow(clippy::missing_panics_doc)] // Needed because `tokio::main` calls `unwrap()`
+    #[tokio::main]
+    pub async fn starknet_get_chain_id(&self) -> Result<ChainId, DatabaseError> {
+        let chain_id: Felt = self.get_new_client().chain_id().await?;
+        let chain_id = chain_id.to_hex_string();
+        let chain_id: Vec<&str> = chain_id.split("0x").collect();
+        let decoded_result = hex::decode(chain_id.last().ok_or(DatabaseError::InvalidHex())?)?;
+        let chain_id = std::str::from_utf8(&decoded_result)?;
+        let chain_id = ChainId::from(chain_id.to_string());
+        Ok(chain_id)
+    }
+}

--- a/starknet-replay/tests/test_replay_blocks.rs
+++ b/starknet-replay/tests/test_replay_blocks.rs
@@ -31,7 +31,7 @@ fn test_replay_blocks() {
 
     let block_number = BlockNumber::new(block_number);
 
-    let (transactions, receipts) = storage
+    let (block_header, transactions, receipts) = storage
         .get_transactions_and_receipts_for_block(block_number)
         .unwrap();
 
@@ -43,8 +43,7 @@ fn test_replay_blocks() {
     let transactions = vec![transactions.get(index).unwrap().clone()];
     let receipts = vec![receipts.get(index).unwrap().clone()];
 
-    let header = storage.get_block_header(block_number).unwrap();
-    let replay_block = ReplayBlock::new(header, transactions, receipts).unwrap();
+    let replay_block = ReplayBlock::new(block_header, transactions, receipts).unwrap();
     replay_work.push(replay_block);
 
     let trace_out = None;


### PR DESCRIPTION
This PR introduces the following changes:
- Removed `nightly` from CI because it's not required
- Added result of `chain_id` to `OnceCell`
- Added result of `block_number` to `OnceCell`
- Added `BlockHeader` to the return of `starknet_get_block_with_receipts` to save a call to `starknet_get_block_with_tx_hashes`

This closes #38 